### PR TITLE
Add missing six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     maintainer_email='martin.vejnar@avast.com',
 
     packages=['pe_tools'],
-    install_requires=['grope'],
+    install_requires=['grope', 'six'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
`six` is required by `version_info.py` and `rsrc.py`, but not declared as an install dependency.

It'd probably be better to just drop the `six` requirement altogether since Python 2 is EOL and the codebase uses Py3-isms throughout.