### PR TITLE
Use str instead of six.string_types

### DIFF
--- a/pe_tools/rsrc.py
+++ b/pe_tools/rsrc.py
@@ -1,8 +1,8 @@
 from grope import BlobIO, rope
 from .utils import *
 from .struct3 import Struct3, u16, u32
-import six, time, struct
-#from typing import NamedTuple
+import time, struct
+
 
 class KnownResourceTypes:
     RT_CURSOR = 1
@@ -176,8 +176,8 @@ class _PrepackedResources:
 
 def _prepack(rsrc):
     if isinstance(rsrc, dict):
-        name_keys = [key for key in rsrc.keys() if isinstance(key, six.string_types)]
-        id_keys = [key for key in rsrc.keys() if not isinstance(key, six.string_types)]
+        name_keys = [key for key in rsrc.keys() if isinstance(key, str)]
+        id_keys = [key for key in rsrc.keys() if not isinstance(key, str)]
 
         name_keys.sort()
         id_keys.sort()
@@ -239,7 +239,7 @@ def pe_resources_prepack(rsrc):
     table_size = offs
     for ent in entries:
         if isinstance(ent, _RESOURCE_DIRECTORY_ENTRY):
-            if isinstance(ent.NameOrId, six.string_types):
+            if isinstance(ent.NameOrId, str):
                 ent.NameOrId = (1<<31) | (table_size + add_string(ent.NameOrId))
 
     strings = b''.join(strings)

--- a/pe_tools/version_info.py
+++ b/pe_tools/version_info.py
@@ -1,7 +1,7 @@
 from .struct3 import Struct3, u16, u32
 from .utils import align4
 from grope import rope
-import six, struct
+import struct
 
 class _VS_FIXEDFILEINFO(Struct3):
     dwSignature: u32
@@ -187,7 +187,7 @@ def _pack_node(node):
         value = b''
         hdr.wValueLength = 0
         hdr.wType = 1
-    elif isinstance(node.value, six.string_types):
+    elif isinstance(node.value, str):
         value = node.value.encode('utf-16le') + b'\0\0'
         hdr.wValueLength = len(value) // 2
         hdr.wType = 1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     maintainer_email='martin.vejnar@avast.com',
 
     packages=['pe_tools'],
-    install_requires=['grope', 'six'],
+    install_requires=['grope'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The code only runs on Python 3, where `six.string_types` is always just `str`.

A followup to #2.